### PR TITLE
Separar animais por pastas

### DIFF
--- a/QuatroPatas/Core/Navigator/Sheet.swift
+++ b/QuatroPatas/Core/Navigator/Sheet.swift
@@ -23,6 +23,7 @@ enum Sheet: Identifiable {
     case deleteAccount(onDelete: (DeleteAction) -> Void)
     case webView(URLRequest, onResult: ((URL) -> Void)? = nil)
     case confirmDelete(ConfirmDialogModel)
+    case addFolder(reload: Binding<Bool>)
 
     var id: String {  String(describing: self) }
 }

--- a/QuatroPatas/Core/Navigator/SheetDestinationView.swift
+++ b/QuatroPatas/Core/Navigator/SheetDestinationView.swift
@@ -62,6 +62,8 @@ struct SheetDestinationView: View {
             }
         case .confirmDelete(let dialog):
             ConfirmDeleteView(model: dialog)
+        case .addFolder(let roload):
+            AddFolderView(reload: roload)
         }
     }
 }

--- a/QuatroPatas/Core/Network/Providers/DatabaseProvider.swift
+++ b/QuatroPatas/Core/Network/Providers/DatabaseProvider.swift
@@ -207,4 +207,16 @@ extension DatabaseProvider {
             }
         }
     }
+    
+    func deleteField(
+        in collection: String,
+        id: String,
+        field: String
+    ) async throws {
+        _ = try await updateFields(
+            in: collection,
+            id: id,
+            fields: [field: FieldValue.delete()]
+        )
+    }
 }

--- a/QuatroPatas/Core/View/Components/AnimalCardViewRow.swift
+++ b/QuatroPatas/Core/View/Components/AnimalCardViewRow.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct AnimalCardViewRow: View {
     let animal: Animal
-    let action: () -> Void
-    
+    var action: (() -> Void)? = nil
+
     @CacheProvider(type: .fileManager)
     var cacheProvider
     
@@ -22,7 +22,7 @@ struct AnimalCardViewRow: View {
     }
     
     var body: some View {
-        Button(action: action) {
+        Button(action: action ?? { }) {
             HStack(spacing: Spacing.large.rawValue) {
                 if let firstURL = animal.photos.first, let url = URL(string: firstURL) {
                     CachedAsyncImage(url: url)

--- a/QuatroPatas/Core/View/Modifiers/ToolbarItemModifier.swift
+++ b/QuatroPatas/Core/View/Modifiers/ToolbarItemModifier.swift
@@ -14,6 +14,8 @@ struct ToolbarItemModifier: ViewModifier {
     var color: Color
     var placement: ToolbarItemPlacement
     var action: (() -> Void)
+
+    @Binding var disabled: Bool
     
     func body(content: Content) -> some View {
         content
@@ -25,12 +27,14 @@ struct ToolbarItemModifier: ViewModifier {
                         }
                         .tint(color)
                         .foregroundStyle(color)
+                        .disabled(disabled)
                     } else {
                         Button(label ?? String()) {
                             action()
                         }
                         .tint(color)
                         .foregroundStyle(color)
+                        .disabled(disabled)
                     }
                 }
             }
@@ -38,8 +42,8 @@ struct ToolbarItemModifier: ViewModifier {
 }
 
 extension View {
-    func toolbarItem(label: String? = "", icon: SFIcon? = nil, color: Color = Color.primaryColor, placement: ToolbarItemPlacement = .automatic, action: @escaping () -> Void) -> some View {
-        self.modifier(ToolbarItemModifier(label: label, icon: icon, color: color, placement: placement, action: action))
+    func toolbarItem(label: String? = "", icon: SFIcon? = nil, color: Color = Color.primaryColor, disabled: Binding<Bool> = .constant(false), placement: ToolbarItemPlacement = .automatic,  action: @escaping () -> Void) -> some View {
+        self.modifier(ToolbarItemModifier(label: label, icon: icon, color: color, placement: placement, action: action, disabled: disabled))
     }
 }
 

--- a/QuatroPatas/Core/View/SFIcon.swift
+++ b/QuatroPatas/Core/View/SFIcon.swift
@@ -40,6 +40,7 @@ enum SFIcon: String {
     case annotation = "pencil.and.list.clipboard"
     case report = "megaphone"
     case donate = "gift.fill"
+    case addFolder = "folder.badge.plus"
 
     static func image(_ value: SFIcon, scale: Image.Scale = .large, color: Color = Color.primaryColor) -> some View {
         Image(systemName: value.rawValue)

--- a/QuatroPatas/Localizable.xcstrings
+++ b/QuatroPatas/Localizable.xcstrings
@@ -879,6 +879,9 @@
     "Digite o nome" : {
 
     },
+    "Digite o nome da pasta" : {
+
+    },
     "Digite o seu endereço" : {
 
     },
@@ -1072,6 +1075,9 @@
     "Idade" : {
 
     },
+    "Incluir Animais" : {
+
+    },
     "Informações da Adoção" : {
 
     },
@@ -1133,6 +1139,9 @@
     "Nova nota" : {
 
     },
+    "Nova Pasta" : {
+
+    },
     "Olá, %@" : {
 
     },
@@ -1140,6 +1149,9 @@
 
     },
     "Outro" : {
+
+    },
+    "Pasta" : {
 
     },
     "Perdido" : {
@@ -1189,6 +1201,9 @@
 
     },
     "Registro de Adoção" : {
+
+    },
+    "Remover da Pasta" : {
 
     },
     "Repetir senha" : {

--- a/QuatroPatas/Model/Animal/Animal.swift
+++ b/QuatroPatas/Model/Animal/Animal.swift
@@ -27,6 +27,7 @@ struct Animal: Hashable, Identifiable, Sendable, Codable, Equatable {
     var ownerId: String?
     var adoptionTerm: String?
     var position: Int?
+    var folder: String?
 }
 
 extension Animal {

--- a/QuatroPatas/Screens/AddFolder/AddFolderView.swift
+++ b/QuatroPatas/Screens/AddFolder/AddFolderView.swift
@@ -1,0 +1,92 @@
+//
+//  AddFolderView.swift
+//  QuatroPatas
+//
+//  Created by Vinicius Mesquita Coelho on 13/01/26.
+//
+
+import SwiftUI
+
+struct AddFolderView: View {
+
+    @EnvironmentObject var navigator: Navigator
+    @EnvironmentObject var databaseProvider: DatabaseProvider
+    @EnvironmentObject var userSession: UserSession
+
+    @State var folderName: String = ""
+    @State var disabled: Bool = true
+
+    @State var isPresented: Bool = false
+    @State var isLoading: Bool = false
+    @State var includedAnimals: [Animal] = []
+    
+    @Binding var reload: Bool
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: Spacing.medium.rawValue) {
+                    TextField("Digite o nome da pasta", text: $folderName)
+                        .textFieldStyle(PrimaryTextFieldStyle())
+                    Button("Incluir Animais", systemImage: SFIcon.add.rawValue) {
+                        isPresented = true
+                    }.buttonStyle(OutlineRoundedButtonStyle())
+                }.padding(.horizontal, Padding.large.rawValue)
+                
+                if !includedAnimals.isEmpty {
+                    LazyVStack(spacing: Padding.medium.rawValue) {
+                        ForEach(includedAnimals, id: \.id) { animal in
+                            AnimalCardViewRow(animal: animal, action: nil)
+                        }
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle())
+                                .transition(.opacity)
+                                .padding(.top, Padding.large.rawValue)
+                        }
+                    }.padding(Padding.medium.rawValue)
+                }
+            }
+            .onChange(of: folderName) {
+                disabled = folderName.isEmpty
+            }
+            .navigationTitle("Nova Pasta")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarItem(icon: .checkmark, disabled: $disabled, placement: .confirmationAction) {
+                for animal in includedAnimals {
+                    Task {
+                        await addFolderToAnimal(animal: animal)
+                    }
+                }
+                navigator.dismiss()
+                reload.toggle()
+            }
+            .toolbarItem(icon: .close, placement: .cancellationAction) {
+                navigator.dismiss()
+            }
+            .sheet(isPresented: $isPresented) {
+                IncludeAnimalsView(includedAnimals: $includedAnimals, isPresented: $isPresented)
+            }
+        }
+    }
+    
+    func addFolderToAnimal(animal: Animal) async {
+        do {
+            guard let path = animalPathBuilder(), let animalId = animal.id else {
+                throw EditAnimalError.pathError
+            }
+            _ = try await databaseProvider.updateFields(
+                in: path,
+                id: animalId,
+                fields: ["folder": folderName]
+            )
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
+    func animalPathBuilder() -> String? {
+        guard let userId = userSession.user?.id else { return nil }
+        return "users/\(userId)/animals"
+    }
+}

--- a/QuatroPatas/Screens/AddFolder/IncludeAnimalsView.swift
+++ b/QuatroPatas/Screens/AddFolder/IncludeAnimalsView.swift
@@ -1,0 +1,66 @@
+//
+//  IncludeAnimalsView.swift
+//  QuatroPatas
+//
+//  Created by Vinicius Mesquita Coelho on 13/01/26.
+//
+
+import SwiftUI
+
+struct IncludeAnimalsView: View {
+
+    @Binding var includedAnimals: [Animal]
+
+    @State private var selectedRows: Set<Animal.ID> = []
+    @State private var animals: [Animal] = []
+    
+    @Binding var isPresented: Bool
+    
+    @EnvironmentObject var databaseProvider: DatabaseProvider
+    @EnvironmentObject var userSession: UserSession
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                ForEach(animals, id: \.id) { animal in
+                    SelectableAnimalRow(
+                        animal: animal,
+                        isSelected: selectedRows.contains(animal.id)
+                    ) {
+                        toggleSelection(for: animal)
+                    }
+                }
+            }
+            .task {
+                await fetchAllAnimals()
+            }
+            .toolbarItem(label: "Fechar", placement: .topBarLeading) {
+                isPresented = false
+            }.toolbarItem(label: "Confirmar", placement: .topBarTrailing) {
+                includedAnimals = animals.filter {
+                    selectedRows.contains($0.id)
+                }
+                isPresented = false
+            }
+        }.navigationTitle("Incluir Animais")
+    }
+
+    private func toggleSelection(for animal: Animal) {
+        if selectedRows.contains(animal.id) {
+            selectedRows.remove(animal.id)
+        } else {
+            selectedRows.insert(animal.id)
+        }
+    }
+    
+    @MainActor
+    func fetchAllAnimals() async {
+        do {
+            let userId = userSession.user?.id ?? ""
+            let items: [Animal] = try await databaseProvider.fetch(from: "users/\(userId)/animals")
+            self.animals = items
+        } catch {
+            print("❌ Fetch error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/QuatroPatas/Screens/AddFolder/SelectableAnimalRow.swift
+++ b/QuatroPatas/Screens/AddFolder/SelectableAnimalRow.swift
@@ -1,0 +1,44 @@
+//
+//  SelectableAnimalRow.swift
+//  QuatroPatas
+//
+//  Created by Vinicius Mesquita Coelho on 14/01/26.
+//
+
+import SwiftUI
+
+struct SelectableAnimalRow: View {
+
+    let animal: Animal
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: Spacing.large.rawValue) {
+            if let firstURL = animal.photos.first, let url = URL(string: firstURL) {
+                CachedAsyncImage(url: url)
+                    .scaledToFill()
+                    .frame(width: 70, height: 50)
+                    .clipShape(Circle())
+            }
+            
+            Text(animal.name)
+
+            Spacer()
+
+            if isSelected {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.blue)
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(isSelected ? Color.blue.opacity(0.15) : Color.clear)
+        )
+        .contentShape(Rectangle()) // permite tocar na row inteira
+        .onTapGesture {
+            action()
+        }
+    }
+}

--- a/QuatroPatas/Screens/AnimalWallet/AnimalWalletView.swift
+++ b/QuatroPatas/Screens/AnimalWallet/AnimalWalletView.swift
@@ -171,6 +171,17 @@ struct AnimalWalletView: View {
                 }
                 .padding(.top, Padding.medium.rawValue)
             }
+            
+            if let folder = animal.folder {
+                VStack(alignment: .leading, spacing: Spacing.small.rawValue) {
+                    Text("Pasta")
+                        .font(.headline)
+                    Text(folder)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.top, Padding.medium.rawValue)
+            }
         }
         .padding()
         .background(

--- a/QuatroPatas/Screens/AnimalsList/AnimalsListView.swift
+++ b/QuatroPatas/Screens/AnimalsList/AnimalsListView.swift
@@ -22,6 +22,9 @@ struct AnimalsListView: View {
     @State private var isLoading: Bool = false
     @State private var searchText: String = ""
     
+    @State private var selectedFolder: String = "Todos"
+    @State private var reloadAnimals: Bool = false
+
     var listType: AnimalListType
     
     var navigationBarTitle: String {
@@ -34,25 +37,56 @@ struct AnimalsListView: View {
     }
     
     var filteredAnimals: [Animal] {
-        if searchText.isEmpty {
-            return animals
-        } else {
-            return animals.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+        animals.filter { animal in
+            let matchesSearch =
+                searchText.isEmpty ||
+                animal.name.localizedCaseInsensitiveContains(searchText)
+
+            let matchesFolder =
+                selectedFolder.lowercased() == "todos" ||
+                animal.folder == selectedFolder
+
+            return matchesSearch && matchesFolder
         }
+    }
+    
+    var folders: [String] {
+        Array(
+            Set(animals.compactMap { $0.folder })
+        ).sorted()
     }
     
     var body: some View {
         ScrollView {
+            if !folders.isEmpty {
+                Picker("Segment", selection: $selectedFolder) {
+                    ForEach(["Todos"] + folders, id: \.self) { folder in
+                        Text(folder)
+                    }
+                }
+                .padding(Padding.medium.rawValue)
+                .pickerStyle(.segmented)
+            }
             LazyVStack(spacing: Padding.medium.rawValue) {
                 ForEach(filteredAnimals, id: \.id) { animal in
-                    AnimalCardViewRow(animal: animal) {
+                    AnimalCardViewRow(animal: animal, action: {
                         switch listType {
                         case .myAnimals:
                             didSelectMyAnimal(animal: animal)
                         case .ongAnimals:
                             didSelectMyAnimal(animal: animal)
                         }
-                    }
+                    })
+                    .if(selectedFolder != "Todos", transform: { view in
+                        view.contextMenu(menuItems: {
+                            Button("Remover da Pasta") {
+                                Task {
+                                    await removeFromFolder(animal: animal)
+                                    reloadAnimals.toggle()
+                                }
+                            }
+                        })
+                    })
                     .padding(.horizontal, Padding.medium.rawValue)
                 }
                 
@@ -70,6 +104,16 @@ struct AnimalsListView: View {
         .if(animals.count >= 10) { view in
             view.searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Buscar animal pelo nome")
         }
+        .onChange(of: reloadAnimals) {
+            Task {
+                await fetchAllAnimals()
+            }
+        }
+        .onChange(of: filteredAnimals) {
+            if filteredAnimals.isEmpty {
+                selectedFolder = "Todos"
+            }
+        }
         .task {
             await fetchAllAnimals()
         }
@@ -79,13 +123,46 @@ struct AnimalsListView: View {
         .toolbarItem(icon: .back, placement: .topBarLeading) {
             navigator.dismiss()
         }
-        .toolbarItem(icon: .add, placement: .topBarTrailing) {
-            addAnimal()
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button(String(), systemImage: SFIcon.addFolder.rawValue) {
+                    addFolder()
+                }
+                Button(String(), systemImage: SFIcon.add.rawValue) {
+                    addAnimal()
+                }
+            } label: {
+                SFIcon.image(.add)
+            }
         }
     }
     
     func addAnimal() {
         navigator.navigate(to: .addAnimal)
+    }
+    
+    func addFolder() {
+        navigator.present(sheet: .addFolder(reload: $reloadAnimals))
+    }
+    
+    func removeFromFolder(animal: Animal) async {
+        do {
+            guard let path = animalPathBuilder(), let animalId = animal.id else {
+                throw EditAnimalError.pathError
+            }
+            _ = try await databaseProvider.deleteField(
+                in: path,
+                id: animalId,
+                field: "folder"
+            )
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
+    func animalPathBuilder() -> String? {
+        guard let userId = userSession.user?.id else { return nil }
+        return "users/\(userId)/animals"
     }
     
     @MainActor


### PR DESCRIPTION
Essa funcionalidade foi adicionada a partir de uma necessidade real do abrigo onde existem 3 locais diferentes onde os animais estão abrigados.

O objetivo é ajudar a ONG a ter o controle de qual abrigo aquele animal pertence para realizar o manejo correto.

Funcionalidades adicionadas:

- Criar Pasta ( variável opcional do animal )
- Exibir pastas existentes
- Remover animais das pastas
- Exibir animais pertencentes a cada pasta

https://github.com/user-attachments/assets/412d9b9e-834f-4f01-9dea-666535fb2350

